### PR TITLE
Adding a GH workflow to publish release artifacts

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,7 +1,7 @@
 name: Publish package to GitHub Packages
 on:
-  release:
-    types: [created]
+  push:
+    branches: [ main ]
 
 jobs:
   publish:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,27 @@
+name: Publish package to GitHub Packages
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+
+      - name: Publish package
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,11 @@ buildscript {
 }
 
 apply plugin: 'java'
+apply plugin: 'maven-publish'
 
 group 'ai.levo'
-version '2.0.0'
+version '0.1.0'
+
 def burpExtensionHomepage = 'https://github.com/levoai/levoai-burp-extension'
 def burpExtensionJarName = 'LevoAiBurpExtension.jar'
 
@@ -37,4 +39,17 @@ task fatJar(type: Jar) {
     archiveFileName = burpExtensionJarName
     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = "https://maven.pkg.github.com/octocat/hello-world"
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -45,11 +45,16 @@ publishing {
     repositories {
         maven {
             name = "GitHubPackages"
-            url = "https://maven.pkg.github.com/octocat/hello-world"
+            url = uri("https://maven.pkg.github.com/levoai/levoai-burp-extension")
             credentials {
                 username = System.getenv("GITHUB_ACTOR")
                 password = System.getenv("GITHUB_TOKEN")
             }
+        }
+    }
+    publications {
+        gpr(MavenPublication) {
+            from(components.java)
         }
     }
 }

--- a/src/main/java/ai/levo/HttpMessageListener.java
+++ b/src/main/java/ai/levo/HttpMessageListener.java
@@ -3,12 +3,17 @@ package ai.levo;
 import burp.*;
 
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Implementation of HTTP activity listener.
  */
 public class HttpMessageListener implements IHttpListener {
-    private static final Set<String> IGNORED_EXTENSIONS = Set.of(".json", ".js", ".html", ".png", ".jpg", ".gif");
+    private static final String COMMA_SEPARATED_EXTENSIONS =
+            "css,ico,gif,jpg,jpeg,png,bmp,svg,avi,mpg,mpeg,mp3,m3u8,woff,woff2,ttf,eot,mp3,mp4,wav,mpg,mpeg,avi,mov,wmv,doc,xls,pdf,zip,tar,7z,rar,tgz,gz,exe,rtp";
+    private static final Set<String> IGNORED_EXTENSIONS =
+            Stream.of(COMMA_SEPARATED_EXTENSIONS.split(",")).map(s -> "." + s).collect(Collectors.toSet());
 
     /**
      * Ref on handler that will send HTTP messages to Levo's Satellite.
@@ -41,6 +46,12 @@ public class HttpMessageListener implements IHttpListener {
     @Override
     public void processHttpMessage(int toolFlag, boolean messageIsRequest, IHttpRequestResponse message) {
         if (messageIsRequest) {
+            return;
+        }
+
+        String toolName = callbacks.getToolName(toolFlag);
+        // For now only process proxy's traffic.
+        if (!"TOOL_PROXY".equalsIgnoreCase(toolName)) {
             return;
         }
 


### PR DESCRIPTION
Other changes:
- Only processes the trace coming from Burp's proxy tool, ignore other traffic.