### PR TITLE
Fix issue with sending response headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'java'
 apply plugin: 'maven-publish'
 
 group 'ai.levo'
-version '0.1.12'
+version '0.1.13'
 
 def burpExtensionHomepage = 'https://github.com/levoai/levoai-burp-extension'
 def burpExtensionJarName = 'LevoAiBurpExtension.jar'

--- a/src/main/java/ai/levo/HttpMessagePublisher.java
+++ b/src/main/java/ai/levo/HttpMessagePublisher.java
@@ -131,19 +131,19 @@ public class HttpMessagePublisher implements IExtensionStateListener {
             request.getHeaders().put(":path", reqInfo.getUrl().getPath());
         }
 
-        String requestBody = callbacks.getHelpers().bytesToString(reqContent);
-        String[] parts = requestBody.split(TWO_LINES_PATTERN);
-        if (parts.length > 1 && parts[1].length() > 0) {
+        String[] requestParts = callbacks.getHelpers().bytesToString(reqContent).split(TWO_LINES_PATTERN);
+        if (requestParts.length > 1 && !requestParts[1].isEmpty()) {
             // Base64 encode the body.
-            request.setBody(callbacks.getHelpers().base64Encode(parts[1]));
+            request.setBody(callbacks.getHelpers().base64Encode(requestParts[1]));
         } else {
             request.setBody("");
         }
 
         HttpMessage.Response response = new HttpMessage.Response();
+        String[] responseParts = callbacks.getHelpers().bytesToString(resContent).split(TWO_LINES_PATTERN);
 
         // Create response headers from the first part of the response. Ignore the status line.
-        String[] responseHeaders = parts[0].split(NEW_LINE_PATTERN);
+        String[] responseHeaders = responseParts[0].split(NEW_LINE_PATTERN);
         if (responseHeaders.length > 1) {
             // Create a list from an array and remove the first element since that's status line.
             List<String> headers = java.util.Arrays.asList(responseHeaders);
@@ -161,11 +161,9 @@ public class HttpMessagePublisher implements IExtensionStateListener {
             alertWriter.writeAlert("Not sending response body for content-type: " + contentType + " to Levo.");
             response.setBody("");
         } else {
-            String responseBody = callbacks.getHelpers().bytesToString(resContent);
-            parts = responseBody.split(TWO_LINES_PATTERN);
-            if (parts.length > 1 && parts[1].length() > 0) {
+            if (responseParts.length > 1 && !responseParts[1].isEmpty()) {
                 // Base64 encode the response body.
-                response.setBody(callbacks.getHelpers().base64Encode(parts[1]));
+                response.setBody(callbacks.getHelpers().base64Encode(responseParts[1]));
             } else {
                 // Don't drop the message if the response body is empty.
                 response.setBody("");


### PR DESCRIPTION
The request headers were being sent for both the request as well as the response headers while exporting.