### PR TITLE
CU-86ba88r4j ci: Add release-note: workflow in other repos

### DIFF
--- a/.github/workflows/on-prem-release-note.yml
+++ b/.github/workflows/on-prem-release-note.yml
@@ -1,0 +1,29 @@
+# Enforces a `release-note:` block in every PR description, and autofills
+# `release-note: NONE` for cleanup-style PRs (chore/refactor/test/docs/ci/build).
+#
+# Core logic lives in the levoai/internal-actions repo as a composite action:
+#   levoai/internal-actions/release-note-validator
+#
+# The action does TWO things in order:
+#   1. Auto-add `release-note: NONE` to PR body if title matches the cleanup prefix
+#   2. Verify the PR body contains a `release-note:` line, fail merge if missing
+
+name: "On-prem release-note: check and auto-fill bot"
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  validate:
+    name: "Validate release-note: line"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: levoai/internal-actions/release-note-validator@main
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          pr-title:  ${{ github.event.pull_request.title }}
+


### PR DESCRIPTION
## Summary

Wires levoai-burp-extension into the new release-note convention by: 
Adding a tiny caller workflow that invokes the composite action
   `levoai/internal-actions/release-note-validator`

Part of the v1 release-notes automation tracked in (proposal inside platform-infrastructure repo): [`release-engineering.md`](https://github.com/levoai/platform-infrastructure/pull/698)

## Files changed

| File | Change | Purpose |
|---|---|---|
| `.github/workflows/on-prem-release-note.yml` | NEW | Caller workflow — invokes `levoai/internal-actions/release-note-validator` on every PR event |

## What changes for engineers

After this PR merges, every PR opened in platform-services will:

1. Show the `release-note:` line pre-filled in the description (via PR template)
2. Auto-get `release-note: NONE` prepended if the title starts with
   `chore:`, `refactor:`, `test:`, `docs:`, `ci:`, or `build:`
3. Be blocked from merging if no `release-note:` line is present

**Engineers must add ONE of:**
```
release-note: NONE
release-note: <one-line customer-facing summary>
release-note: BREAKING: <summary + upgrade procedure>
```