### PR TITLE
CU-86ba9pz96 ci: Skip all workflows on draft PRs

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -4,9 +4,11 @@ env:
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   build:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- Skip all CI workflows on draft PRs to save runner resources.
- Add `ready_for_review` to `pull_request` triggers so workflows fire when a draft is marked as ready.
- Add `if: github.event.pull_request.draft == false` (or the multi-trigger variant) on every job that could fire from a PR event.

## Workflows updated
- `pr_build.yml` — added `types: [opened, synchronize, reopened, ready_for_review]` to `pull_request` trigger; added `if: github.event.pull_request.draft == false` on `build` job.

## Test plan
- [ ] Open a draft PR — no workflows run.
- [ ] Push to the draft PR — still skipped.
- [ ] Mark "Ready for review" — workflows trigger.
- [ ] Non-PR triggers still run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)